### PR TITLE
feat: storage listener for hide player

### DIFF
--- a/src/pages/content/Player.tsx
+++ b/src/pages/content/Player.tsx
@@ -301,10 +301,18 @@ function Player({ room, player }: Props) {
     }
   };
 
-  const handlePlayerVisiblityChange = () => {
-    let curr = localStorage.getItem("42fm:hidePlayer");
+  const handlePlayerVisibilityChange = () => {
+    const oldValue = localStorage.getItem('42fm:hidePlayer');
+    const newValue = oldValue === 'true' ? 'false' : 'true';
 
-    localStorage.setItem("42fm:hidePlayer", curr === "true" ? "false" : "true");
+    localStorage.setItem('42fm:hidePlayer', newValue);
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: '42fm:hidePlayer',
+        oldValue: oldValue,
+        newValue,
+      })
+    );
   };
 
   if (!isConnected) {
@@ -360,7 +368,7 @@ function Player({ room, player }: Props) {
                 <ButtonsWrapper>
                   <ButtonIcon
                     icon={<UilVideo {...defaultIconProps} />}
-                    onClick={() => handlePlayerVisiblityChange()}
+                    onClick={() => handlePlayerVisibilityChange()}
                     tooltip="Toggle Player"
                     placement="top-end"
                   />

--- a/src/pages/content/YoutubePlayer.tsx
+++ b/src/pages/content/YoutubePlayer.tsx
@@ -72,26 +72,34 @@ function YoutubePlayer() {
     };
   }, [isDown]);
 
-  // Works for now
   useEffect(() => {
-    const interval = setInterval(() => {
-      const val = localStorage.getItem("42fm:hidePlayer") === "true";
+    const savedIsHidden = localStorage.getItem("42fm:hidePlayer") === "true";
 
-      if (val !== isHidden) {
-        setIsHidden(val);
-      }
-    }, 1000);
+    setIsHidden(savedIsHidden);
+
+    const handleStorageChange = (e: StorageEvent) => {
+      if (e.key !== "42fm:hidePlayer") return;
+
+      const hidePlayer = e.newValue === "true";
+
+      setIsHidden(hidePlayer);
+    };
+
+    window.addEventListener("storage", handleStorageChange);
 
     return () => {
-      clearInterval(interval);
+      window.removeEventListener("storage", handleStorageChange);
     };
-  });
+  }, []);
 
-  const handlePlayerVisiblityChange = () => {
-    let curr = localStorage.getItem("42fm:hidePlayer");
+  const handlePlayerVisibilityChange = () => 
+    setIsHidden(oldValue => {
+      const newValue = !oldValue;
 
-    localStorage.setItem("42fm:hidePlayer", curr === "true" ? "false" : "true");
-  };
+      localStorage.setItem("42fm:hidePlayer", String(newValue));
+    
+      return newValue;
+    });
 
   return (
     <Wrapper
@@ -131,7 +139,7 @@ function YoutubePlayer() {
           tooltip="Hide player"
           placement="right"
           icon={<UilVideoSlash {...defaultIconProps} />}
-          onClick={() => handlePlayerVisiblityChange()}
+          onClick={() => handlePlayerVisibilityChange()}
         />
         <ButtonIcon
           tooltip="Snap to top right"

--- a/src/pages/content/content.tsx
+++ b/src/pages/content/content.tsx
@@ -122,6 +122,11 @@ const badgeOwners = [
     badge: createBadge("contributor"),
   },
   {
+    twitch_id: "47930095",
+    twitch_name: "syki_",
+    badge: createBadge("contributor"),
+  },
+  {
     twitch_id: "773987717",
     twitch_name: "42fm",
     badge: createBadge("bot"),


### PR DESCRIPTION
Hello, I hope you like my optimization

Previously there was useEffect without a dependency array, this is very suboptimal and not recommended practice.

As a clarification, we have to do `window.dispatchEvent(` manually because the browser API sends an event only when we change storage in another tab

Thanks for creating this extension, I really like it